### PR TITLE
feat: differentiate midpoint marker from origin markers

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.6",
     "@radix-ui/react-slot": "^1.1.2",
-    "@react-google-maps/api": "^2.20.6",
     "@tailwindcss/postcss": "^4.0.0",
     "@tanstack/react-query": "^5.51.23",
+    "@vis.gl/react-google-maps": "^1.5.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,15 +14,15 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.1.2
         version: 1.1.2(@types/react@19.0.9)(react@19.0.0)
-      '@react-google-maps/api':
-        specifier: ^2.20.6
-        version: 2.20.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@tailwindcss/postcss':
         specifier: ^4.0.0
         version: 4.0.6
       '@tanstack/react-query':
         specifier: ^5.51.23
         version: 5.66.3(react@19.0.0)
+      '@vis.gl/react-google-maps':
+        specifier: ^1.5.1
+        version: 1.5.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -336,12 +336,6 @@ packages:
   '@fastify/busboy@2.1.1':
     resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
     engines: {node: '>=14'}
-
-  '@googlemaps/js-api-loader@1.16.8':
-    resolution: {integrity: sha512-CROqqwfKotdO6EBjZO/gQGVTbeDps5V7Mt9+8+5Q+jTg5CRMi3Ii/L9PmV3USROrt2uWxtGzJHORmByxyo9pSQ==}
-
-  '@googlemaps/markerclusterer@2.5.3':
-    resolution: {integrity: sha512-x7lX0R5yYOoiNectr10wLgCBasNcXFHiADIBdmn7jQllF2B5ENQw5XtZK+hIw4xnV0Df0xhN4LN98XqA5jaiOw==}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -710,18 +704,6 @@ packages:
       '@types/react':
         optional: true
 
-  '@react-google-maps/api@2.20.6':
-    resolution: {integrity: sha512-frxkSHWbd36ayyxrEVopSCDSgJUT1tVKXvQld2IyzU3UnDuqqNA3AZE4/fCdqQb2/zBQx3nrWnZB1wBXDcrjcw==}
-    peerDependencies:
-      react: ^16.8 || ^17 || ^18 || ^19
-      react-dom: ^16.8 || ^17 || ^18 || ^19
-
-  '@react-google-maps/infobox@2.20.0':
-    resolution: {integrity: sha512-03PJHjohhaVLkX6+NHhlr8CIlvUxWaXhryqDjyaZ8iIqqix/nV8GFdz9O3m5OsjtxtNho09F/15j14yV0nuyLQ==}
-
-  '@react-google-maps/marker-clusterer@2.20.0':
-    resolution: {integrity: sha512-tieX9Va5w1yP88vMgfH1pHTacDQ9TgDTjox3tLlisKDXRQWdjw+QeVVghhf5XqqIxXHgPdcGwBvKY6UP+SIvLw==}
-
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
@@ -896,6 +878,12 @@ packages:
   '@typescript-eslint/visitor-keys@8.24.0':
     resolution: {integrity: sha512-kArLq83QxGLbuHrTMoOEWO+l2MwsNS2TGISEdx8xgqpkbytB07XmlQyQdNDrCc1ecSqx0cnmhGvpX+VBwqqSkg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@vis.gl/react-google-maps@1.5.1':
+    resolution: {integrity: sha512-SQwr06IOeTEUTtnMWAianbcjT3u4rANm2AKMAU7cjzghHVWGNViYWY6k7oUHyeurYg//OzsgcXtCPKiis/fTtA==}
+    peerDependencies:
+      react: '>=16.8.0 || ^19.0 || ^19.0.0-rc'
+      react-dom: '>=16.8.0 || ^19.0 || ^19.0.0-rc'
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -1485,9 +1473,6 @@ packages:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
 
-  invariant@2.2.4:
-    resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
-
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
     engines: {node: '>= 0.4'}
@@ -1645,9 +1630,6 @@ packages:
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
-
-  kdbush@4.0.2:
-    resolution: {integrity: sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -2155,9 +2137,6 @@ packages:
       babel-plugin-macros:
         optional: true
 
-  supercluster@8.0.1:
-    resolution: {integrity: sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==}
-
   superjson@2.2.2:
     resolution: {integrity: sha512-5JRxVqC8I8NuOUjzBbvVJAKNM8qoVuH0O77h4WInc/qC2q5IreqKxYwgkga3PfA22OayK2ikceb/B26dztPl+Q==}
     engines: {node: '>=16'}
@@ -2498,13 +2477,6 @@ snapshots:
 
   '@fastify/busboy@2.1.1': {}
 
-  '@googlemaps/js-api-loader@1.16.8': {}
-
-  '@googlemaps/markerclusterer@2.5.3':
-    dependencies:
-      fast-deep-equal: 3.1.3
-      supercluster: 8.0.1
-
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.6':
@@ -2781,21 +2753,6 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.0.9
 
-  '@react-google-maps/api@2.20.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
-    dependencies:
-      '@googlemaps/js-api-loader': 1.16.8
-      '@googlemaps/markerclusterer': 2.5.3
-      '@react-google-maps/infobox': 2.20.0
-      '@react-google-maps/marker-clusterer': 2.20.0
-      '@types/google.maps': 3.58.1
-      invariant: 2.2.4
-      react: 19.0.0
-      react-dom: 19.0.0(react@19.0.0)
-
-  '@react-google-maps/infobox@2.20.0': {}
-
-  '@react-google-maps/marker-clusterer@2.20.0': {}
-
   '@rtsao/scc@1.1.0': {}
 
   '@rushstack/eslint-patch@1.10.5': {}
@@ -2979,6 +2936,13 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.24.0
       eslint-visitor-keys: 4.2.0
+
+  '@vis.gl/react-google-maps@1.5.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@types/google.maps': 3.58.1
+      fast-deep-equal: 3.1.3
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
 
   acorn-jsx@5.3.2(acorn@8.14.0):
     dependencies:
@@ -3754,10 +3718,6 @@ snapshots:
       hasown: 2.0.2
       side-channel: 1.1.0
 
-  invariant@2.2.4:
-    dependencies:
-      loose-envify: 1.4.0
-
   is-array-buffer@3.0.5:
     dependencies:
       call-bind: 1.0.8
@@ -3922,8 +3882,6 @@ snapshots:
       array.prototype.flat: 1.3.3
       object.assign: 4.1.7
       object.values: 1.2.1
-
-  kdbush@4.0.2: {}
 
   keyv@4.5.4:
     dependencies:
@@ -4483,10 +4441,6 @@ snapshots:
     dependencies:
       client-only: 0.0.1
       react: 19.0.0
-
-  supercluster@8.0.1:
-    dependencies:
-      kdbush: 4.0.2
 
   superjson@2.2.2:
     dependencies:

--- a/src/app/components/markerMap.tsx
+++ b/src/app/components/markerMap.tsx
@@ -28,12 +28,12 @@ const MarkerMap = ({
 
   return (
     <Map
-      mapId="marker-map" // required when using AdvancedMarker
+      mapId="marker-map" 
       colorScheme="FOLLOW_SYSTEM"
       defaultZoom={10}
       defaultCenter={{ lat: midpoint.latitude, lng: midpoint.longitude }}
-      gestureHandling={"greedy"} // copied from example, not sure
-      disableDefaultUI={true} // copied from example, not sure
+      gestureHandling={"greedy"} 
+      disableDefaultUI={true} 
       className="w-full h-screen"
     >
       {coordinates.map((coord, index) => (

--- a/src/app/components/markerMap.tsx
+++ b/src/app/components/markerMap.tsx
@@ -1,7 +1,6 @@
 import React from "react";
-import { GoogleMap, useJsApiLoader } from "@react-google-maps/api";
-import { Marker } from "@react-google-maps/api";
 import { Coordinates } from "@/server/handlers/maps/search";
+import { Map, useMap, AdvancedMarker, Pin } from "@vis.gl/react-google-maps";
 
 const MarkerMap = ({
   coordinates,
@@ -12,71 +11,72 @@ const MarkerMap = ({
   midpoint: Coordinates;
   iterations: Coordinates[];
 }) => {
-  const { isLoaded } = useJsApiLoader({
-    id: "google-map-script",
-    googleMapsApiKey: process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY!,
-  });
+  const map = useMap();
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [map, setMap] = React.useState<google.maps.Map>();
+  React.useEffect(() => {
+    if (!map) return;
 
-  const onLoad = React.useCallback(
-    function callback(map: google.maps.Map) {
-      // Fit the map to the coordinates
-      if (coordinates.length > 0) {
-        const bounds = new window.google.maps.LatLngBounds();
-        [...coordinates, midpoint].forEach((coord) => {
-          bounds.extend({ lat: coord.latitude, lng: coord.longitude });
-        });
-        map.fitBounds(bounds);
-      }
-      setMap(map);
-    },
-    [coordinates, midpoint]
-  );
+    // Fit the map to the coordinates
+    if (coordinates.length > 0) {
+      const bounds = new window.google.maps.LatLngBounds();
+      [...coordinates, midpoint].forEach((coord) => {
+        bounds.extend({ lat: coord.latitude, lng: coord.longitude });
+      });
+      map.fitBounds(bounds);
+    }
+  }, [map, coordinates, midpoint]);
 
-  const onUnmount = React.useCallback(function callback() {
-    setMap(undefined);
-  }, []);
-
-  return isLoaded ? (
-    <GoogleMap
-      mapContainerClassName="w-full h-screen"
-      center={{
-        lat: midpoint.latitude,
-        lng: midpoint.longitude,
-      }}
-      zoom={10}
-      onLoad={onLoad}
-      onUnmount={onUnmount}
+  return (
+    <Map
+      mapId="marker-map" // required when using AdvancedMarker
+      colorScheme="FOLLOW_SYSTEM"
+      defaultZoom={10}
+      defaultCenter={{ lat: midpoint.latitude, lng: midpoint.longitude }}
+      gestureHandling={"greedy"} // copied from example, not sure
+      disableDefaultUI={true} // copied from example, not sure
+      className="w-full h-screen"
     >
-      {[...coordinates, midpoint].map((coord, index) => (
-        <Marker
-          key={index}
+      {coordinates.map((coord, index) => (
+        <AdvancedMarker
+          key={`coord-${index}`}
           position={{ lat: coord.latitude, lng: coord.longitude }}
-        />
+        >
+          <Pin
+            scale={1.25}
+            // Can change background and borderColor also
+            glyphColor={"#A71010"}
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+              className="size-5"
+            >
+              <path
+                fillRule="evenodd"
+                d="M9.293 2.293a1 1 0 0 1 1.414 0l7 7A1 1 0 0 1 17 11h-1v6a1 1 0 0 1-1 1h-2a1 1 0 0 1-1-1v-3a1 1 0 0 0-1-1H9a1 1 0 0 0-1 1v3a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1v-6H3a1 1 0 0 1-.707-1.707l7-7Z"
+                clipRule="evenodd"
+              />
+            </svg>
+          </Pin>
+        </AdvancedMarker>
       ))}
+
+      <AdvancedMarker
+        position={{ lat: midpoint.latitude, lng: midpoint.longitude }}
+      />
+
       {iterations.map((iter, index) => (
-        <Marker
-          key={index}
+        <AdvancedMarker
+          key={`iter-${index}`}
           position={{ lat: iter.latitude, lng: iter.longitude }}
-          label={{
-            text: (index + 1).toString(),
-            color: "#000000",
-            fontSize: "12px",
-          }}
-          icon={{
-            path: google.maps.SymbolPath.CIRCLE,
-            fillColor: "#00FF00",
-            fillOpacity: 1,
-            strokeWeight: 0,
-            scale: 8,
-          }}
-        />
+        >
+          <div className="flex items-center justify-center bg-green-500 text-black font-bold rounded-full w-6 h-6 border border-white text-xs">
+            {index + 1}
+          </div>
+        </AdvancedMarker>
       ))}
-    </GoogleMap>
-  ) : (
-    <div>Loading...</div>
+    </Map>
   );
 };
 

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -12,6 +12,7 @@ import {
 import MarkerMap from "../components/markerMap";
 import useSearch from "../hooks/useSearch";
 import { Spinner } from "../components/ui/spinner";
+import { APIProvider } from "@vis.gl/react-google-maps";
 
 const Places = () => {
   const searchParams = useSearchParams();
@@ -84,11 +85,13 @@ const Places = () => {
           </Card>
         ))}
       </div>
-      <MarkerMap
-        coordinates={search.data.coordinates}
-        midpoint={search.data.midpoint}
-        iterations={iterations}
-      />
+      <APIProvider apiKey={process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY!}>
+        <MarkerMap
+          coordinates={search.data.coordinates}
+          midpoint={search.data.midpoint}
+          iterations={iterations}
+        />
+      </APIProvider>
     </div>
   );
 };


### PR DESCRIPTION
Closes #2 

![image](https://github.com/user-attachments/assets/21955165-1028-47ac-9854-d3f7717c6ed1)

- Home svg icon is from heroicons
- Following the same colours as the default pin for now (can be changed using a combination of the `borderColor`, `background` and `glyphColor` props of the Pin component)
- Scaled the origin markers up by 1.25 because they felt too small, but can be undone 
- Chose "FOLLOW_SYSTEM" for the Map `colorScheme` prop because it made the most sense, but can be undone