### PR TITLE
fix: update category badge colors to match sky-blue theme

### DIFF
--- a/src/components/results/mini-map.tsx
+++ b/src/components/results/mini-map.tsx
@@ -22,8 +22,10 @@ type MiniMapProps = {
 export function MiniMap({
   coordinates,
   midpoint,
+  places,
   isExpanded,
   onToggleExpand,
+  onPlaceSelect,
 }: MiniMapProps) {
   const map = useMap()
 
@@ -35,9 +37,15 @@ export function MiniMap({
       ;[...coordinates, midpoint].forEach((coord) => {
         bounds.extend({ lat: coord.latitude, lng: coord.longitude })
       })
+      places.forEach((place) => {
+        bounds.extend({
+          lat: place.location.latitude,
+          lng: place.location.longitude,
+        })
+      })
       map.fitBounds(bounds, { top: 20, bottom: 20, left: 20, right: 20 })
     }
-  }, [map, coordinates, midpoint])
+  }, [map, coordinates, midpoint, places])
 
   return (
     <div className="relative mx-4 mt-2 overflow-hidden rounded-2xl ring-1 ring-border/50">
@@ -76,6 +84,22 @@ export function MiniMap({
               <MapPin className="h-4 w-4 text-white" />
             </div>
           </AdvancedMarker>
+
+          {/* Place markers */}
+          {places.map((place) => (
+            <AdvancedMarker
+              key={`place-${place.id}`}
+              position={{
+                lat: place.location.latitude,
+                lng: place.location.longitude,
+              }}
+              onClick={() => onPlaceSelect(place)}
+            >
+              <div className="flex h-7 w-7 items-center justify-center rounded-full border-2 border-white bg-sky-blue/70 shadow-md transition-transform hover:scale-110">
+                <MapPin className="h-3.5 w-3.5 text-white" />
+              </div>
+            </AdvancedMarker>
+          ))}
         </Map>
       </div>
 

--- a/src/components/results/mini-map.tsx
+++ b/src/components/results/mini-map.tsx
@@ -51,7 +51,7 @@ export function MiniMap({
     <div className="relative mx-4 mt-2 overflow-hidden rounded-2xl ring-1 ring-border/50">
       <div
         className={cn(
-          "w-full overflow-hidden transition-all duration-300 ease-out",
+          "w-full overflow-hidden transition-all duration-700 ease-out",
           isExpanded ? "h-64" : "h-28"
         )}
       >

--- a/src/components/results/place-card.tsx
+++ b/src/components/results/place-card.tsx
@@ -26,24 +26,24 @@ export function PlaceCard({ place, onSelect }: PlaceCardProps) {
   return (
     <button
       onClick={onSelect}
-      className="group flex w-full items-start gap-4 rounded-2xl bg-card p-4 text-left shadow-sm ring-1 ring-border/50 transition-all active:scale-[0.98]"
+      className="group flex w-full items-start gap-4 rounded-2xl bg-white/15 p-4 text-left shadow-sm ring-1 ring-white/20 backdrop-blur-xl transition-all active:scale-[0.98]"
     >
       {/* Left content */}
       <div className="min-w-0 flex-1">
         {/* Category pill */}
         {category && (
-          <span className="mb-2 inline-block rounded-full bg-sky-blue/10 px-2.5 py-0.5 text-[11px] font-semibold tracking-wide text-sky-blue uppercase">
+          <span className="mb-2 inline-block rounded-full bg-white/20 px-2.5 py-0.5 text-[11px] font-semibold tracking-wide text-white uppercase">
             {category}
           </span>
         )}
 
         {/* Place name */}
-        <h3 className="text-[17px] leading-snug font-bold text-balance text-foreground">
+        <h3 className="text-[17px] leading-snug font-bold text-balance text-white">
           {place.displayName.text}
         </h3>
 
         {/* Location */}
-        <div className="mt-1.5 flex items-center gap-1.5 text-sm text-muted-foreground">
+        <div className="mt-1.5 flex items-center gap-1.5 text-sm text-white/70">
           <MapPin className="h-3.5 w-3.5 flex-shrink-0" />
           <span className="truncate">{suburb}</span>
         </div>
@@ -59,12 +59,12 @@ export function PlaceCard({ place, onSelect }: PlaceCardProps) {
                     ? "fill-amber-400 text-amber-400"
                     : i === fullStars && hasHalfStar
                       ? "fill-amber-400/50 text-amber-400"
-                      : "fill-muted text-muted"
+                      : "fill-white/20 text-white/20"
                 }`}
               />
             ))}
           </div>
-          <span className="text-sm font-semibold text-foreground">
+          <span className="text-sm font-semibold text-white">
             {rating ? rating.toFixed(1) : "N/A"}
           </span>
         </div>
@@ -83,8 +83,8 @@ export function PlaceCard({ place, onSelect }: PlaceCardProps) {
         ) : photoQuery.isLoading ? (
           <Skeleton className="size-20 rounded-xl" />
         ) : (
-          <div className="flex size-8 items-center justify-center rounded-full bg-muted/50 transition-colors group-hover:bg-primary/10">
-            <ChevronRight className="h-4 w-4 text-muted-foreground transition-colors group-hover:text-primary" />
+          <div className="flex size-8 items-center justify-center rounded-full bg-white/20 transition-colors group-hover:bg-white/30">
+            <ChevronRight className="h-4 w-4 text-white/70 transition-colors group-hover:text-white" />
           </div>
         )}
       </div>

--- a/src/components/results/place-card.tsx
+++ b/src/components/results/place-card.tsx
@@ -32,7 +32,7 @@ export function PlaceCard({ place, onSelect }: PlaceCardProps) {
       <div className="min-w-0 flex-1">
         {/* Category pill */}
         {category && (
-          <span className="mb-2 inline-block rounded-full bg-primary/10 px-2.5 py-0.5 text-[11px] font-semibold tracking-wide text-primary uppercase">
+          <span className="mb-2 inline-block rounded-full bg-sky-blue/10 px-2.5 py-0.5 text-[11px] font-semibold tracking-wide text-sky-blue uppercase">
             {category}
           </span>
         )}

--- a/src/components/results/place-card.tsx
+++ b/src/components/results/place-card.tsx
@@ -26,24 +26,24 @@ export function PlaceCard({ place, onSelect }: PlaceCardProps) {
   return (
     <button
       onClick={onSelect}
-      className="group flex w-full items-start gap-4 rounded-2xl bg-white/15 p-4 text-left shadow-sm ring-1 ring-white/20 backdrop-blur-xl transition-all active:scale-[0.98]"
+      className="group flex w-full items-start gap-4 rounded-2xl bg-card p-4 text-left shadow-sm ring-1 ring-border/50 transition-all active:scale-[0.98]"
     >
       {/* Left content */}
       <div className="min-w-0 flex-1">
         {/* Category pill */}
         {category && (
-          <span className="mb-2 inline-block rounded-full bg-white/20 px-2.5 py-0.5 text-[11px] font-semibold tracking-wide text-white uppercase">
+          <span className="mb-2 inline-block rounded-full bg-sky-blue/10 px-2.5 py-0.5 text-[11px] font-semibold tracking-wide text-sky-blue uppercase">
             {category}
           </span>
         )}
 
         {/* Place name */}
-        <h3 className="text-[17px] leading-snug font-bold text-balance text-white">
+        <h3 className="text-[17px] leading-snug font-bold text-balance text-foreground">
           {place.displayName.text}
         </h3>
 
         {/* Location */}
-        <div className="mt-1.5 flex items-center gap-1.5 text-sm text-white/70">
+        <div className="mt-1.5 flex items-center gap-1.5 text-sm text-muted-foreground">
           <MapPin className="h-3.5 w-3.5 flex-shrink-0" />
           <span className="truncate">{suburb}</span>
         </div>
@@ -59,12 +59,12 @@ export function PlaceCard({ place, onSelect }: PlaceCardProps) {
                     ? "fill-amber-400 text-amber-400"
                     : i === fullStars && hasHalfStar
                       ? "fill-amber-400/50 text-amber-400"
-                      : "fill-white/20 text-white/20"
+                      : "fill-muted text-muted"
                 }`}
               />
             ))}
           </div>
-          <span className="text-sm font-semibold text-white">
+          <span className="text-sm font-semibold text-foreground">
             {rating ? rating.toFixed(1) : "N/A"}
           </span>
         </div>
@@ -83,8 +83,8 @@ export function PlaceCard({ place, onSelect }: PlaceCardProps) {
         ) : photoQuery.isLoading ? (
           <Skeleton className="size-20 rounded-xl" />
         ) : (
-          <div className="flex size-8 items-center justify-center rounded-full bg-white/20 transition-colors group-hover:bg-white/30">
-            <ChevronRight className="h-4 w-4 text-white/70 transition-colors group-hover:text-white" />
+          <div className="flex size-8 items-center justify-center rounded-full bg-muted/50 transition-colors group-hover:bg-sky-blue/10">
+            <ChevronRight className="h-4 w-4 text-muted-foreground transition-colors group-hover:text-sky-blue" />
           </div>
         )}
       </div>

--- a/src/components/results/place-detail-sheet.tsx
+++ b/src/components/results/place-detail-sheet.tsx
@@ -67,7 +67,7 @@ export function PlaceDetailSheet({ place, onClose }: PlaceDetailSheetProps) {
                 .map((type) => (
                   <span
                     key={type}
-                    className="rounded-full bg-primary/10 px-2.5 py-0.5 text-[11px] font-semibold tracking-wide text-primary uppercase"
+                    className="rounded-full bg-sky-blue/10 px-2.5 py-0.5 text-[11px] font-semibold tracking-wide text-sky-blue uppercase"
                   >
                     {formatPlaceType(type)}
                   </span>

--- a/src/components/results/results-header.tsx
+++ b/src/components/results/results-header.tsx
@@ -33,11 +33,11 @@ export function ResultsHeader({
   }
 
   return (
-    <header className="sticky top-0 z-20 bg-background">
+    <header className="sticky top-0 z-20 bg-white/15 backdrop-blur-xl">
       {/* Logo bar */}
-      <div className="flex items-center justify-center border-b border-border/40 px-4 py-2">
+      <div className="flex items-center justify-center border-b border-white/20 px-4 py-2">
         <Link to="/" className="group flex items-center gap-1.5">
-          <span className="text-sm font-bold tracking-tight text-sky-blue">
+          <span className="text-sm font-bold tracking-tight text-white">
             meet me halfway
           </span>
         </Link>
@@ -50,19 +50,17 @@ export function ResultsHeader({
             variant="ghost"
             size="icon"
             onClick={onBack}
-            className="h-10 w-10 rounded-full bg-muted/50"
+            className="h-10 w-10 rounded-full bg-white/20 text-white hover:bg-white/30"
             aria-label="Go back"
           >
             <ArrowLeft className="h-5 w-5" />
           </Button>
           <div>
             <div className="flex items-center gap-1.5">
-              <MapPin className="h-4 w-4 text-sky-blue" />
-              <h1 className="text-lg font-bold text-foreground">{cityName}</h1>
+              <MapPin className="h-4 w-4 text-white" />
+              <h1 className="text-lg font-bold text-white">{cityName}</h1>
             </div>
-            <p className="text-xs text-muted-foreground">
-              meeting point for everyone
-            </p>
+            <p className="text-xs text-white/70">meeting point for everyone</p>
           </div>
         </div>
 
@@ -70,7 +68,7 @@ export function ResultsHeader({
           variant="ghost"
           size="icon"
           onClick={handleShare}
-          className="h-10 w-10 rounded-full bg-muted/50"
+          className="h-10 w-10 rounded-full bg-white/20 text-white hover:bg-white/30"
           aria-label="Share results"
         >
           <Share2 className="h-5 w-5" />

--- a/src/components/results/results-header.tsx
+++ b/src/components/results/results-header.tsx
@@ -33,11 +33,11 @@ export function ResultsHeader({
   }
 
   return (
-    <header className="sticky top-0 z-20 bg-white/15 backdrop-blur-xl">
+    <header className="sticky top-0 z-20 bg-background">
       {/* Logo bar */}
-      <div className="flex items-center justify-center border-b border-white/20 px-4 py-2">
+      <div className="flex items-center justify-center border-b border-border/40 px-4 py-2">
         <Link to="/" className="group flex items-center gap-1.5">
-          <span className="text-sm font-bold tracking-tight text-white">
+          <span className="text-sm font-bold tracking-tight text-sky-blue">
             meet me halfway
           </span>
         </Link>
@@ -50,17 +50,19 @@ export function ResultsHeader({
             variant="ghost"
             size="icon"
             onClick={onBack}
-            className="h-10 w-10 rounded-full bg-white/20 text-white hover:bg-white/30"
+            className="h-10 w-10 rounded-full bg-muted/50"
             aria-label="Go back"
           >
             <ArrowLeft className="h-5 w-5" />
           </Button>
           <div>
             <div className="flex items-center gap-1.5">
-              <MapPin className="h-4 w-4 text-white" />
-              <h1 className="text-lg font-bold text-white">{cityName}</h1>
+              <MapPin className="h-4 w-4 text-sky-blue" />
+              <h1 className="text-lg font-bold text-foreground">{cityName}</h1>
             </div>
-            <p className="text-xs text-white/70">meeting point for everyone</p>
+            <p className="text-xs text-muted-foreground">
+              meeting point for everyone
+            </p>
           </div>
         </div>
 
@@ -68,7 +70,7 @@ export function ResultsHeader({
           variant="ghost"
           size="icon"
           onClick={handleShare}
-          className="h-10 w-10 rounded-full bg-white/20 text-white hover:bg-white/30"
+          className="h-10 w-10 rounded-full bg-muted/50"
           aria-label="Share results"
         >
           <Share2 className="h-5 w-5" />

--- a/src/routes/results.tsx
+++ b/src/routes/results.tsx
@@ -35,7 +35,7 @@ function ResultsPage() {
   const searchResult = useSearch(placeIds)
   const navigate = useNavigate()
   const [selectedPlace, setSelectedPlace] = useState<Place | null>(null)
-  const [isMapExpanded, setIsMapExpanded] = useState(false)
+  const [isMapExpanded, setIsMapExpanded] = useState(true)
 
   useEffect(() => {
     if (!placeIdsParam) {

--- a/src/routes/results.tsx
+++ b/src/routes/results.tsx
@@ -205,6 +205,21 @@ function ResultsContent({
         />
       </motion.div>
 
+      {/* Section header — fades up */}
+      <motion.div
+        className="flex items-end justify-between px-4 pt-5"
+        initial={{ opacity: 0, y: 12 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4, ease: [0.22, 1, 0.36, 1], delay: 0.1 }}
+      >
+        <div>
+          <h2 className="text-xl font-bold text-foreground">places to meet</h2>
+          <p className="mt-0.5 text-sm text-muted-foreground">
+            {data.places.length} spots found nearby
+          </p>
+        </div>
+      </motion.div>
+
       {/* Map — fades in */}
       <motion.div
         initial={{ opacity: 0, scale: 0.97 }}
@@ -223,24 +238,7 @@ function ResultsContent({
         </APIProvider>
       </motion.div>
 
-      <main className="flex-1 px-4 pt-5 pb-8">
-        {/* Section header — fades up */}
-        <motion.div
-          className="mb-4 flex items-end justify-between"
-          initial={{ opacity: 0, y: 12 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.4, ease: [0.22, 1, 0.36, 1], delay: 0.25 }}
-        >
-          <div>
-            <h2 className="text-xl font-bold text-foreground">
-              places to meet
-            </h2>
-            <p className="mt-0.5 text-sm text-muted-foreground">
-              {data.places.length} spots found nearby
-            </p>
-          </div>
-        </motion.div>
-
+      <main className="flex-1 px-4 pt-4 pb-8">
         {/* Place cards — staggered entrance */}
         <div className="grid gap-3">
           {data.places.map((place, index) => (

--- a/src/routes/results.tsx
+++ b/src/routes/results.tsx
@@ -35,7 +35,7 @@ function ResultsPage() {
   const searchResult = useSearch(placeIds)
   const navigate = useNavigate()
   const [selectedPlace, setSelectedPlace] = useState<Place | null>(null)
-  const [isMapExpanded, setIsMapExpanded] = useState(true)
+  const [isMapExpanded, setIsMapExpanded] = useState(false)
 
   useEffect(() => {
     if (!placeIdsParam) {
@@ -46,7 +46,7 @@ function ResultsPage() {
   const isLoading = !searchResult.data
 
   return (
-    <div className="flex min-h-svh flex-col bg-background">
+    <div className="flex h-svh flex-col overflow-hidden bg-background">
       <AnimatePresence mode="wait">
         {isLoading ? (
           <ResultsLoadingScreen key="loading" />
@@ -185,9 +185,15 @@ function ResultsContent({
 }) {
   const cityName = data.snap?.cityName || "Midpoint"
 
+  // Expand the map shortly after results appear
+  useEffect(() => {
+    const timer = setTimeout(() => setIsMapExpanded(true), 250)
+    return () => clearTimeout(timer)
+  }, [setIsMapExpanded])
+
   return (
     <motion.div
-      className="flex min-h-svh flex-col"
+      className="flex min-h-0 flex-1 flex-col overflow-hidden"
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       transition={{ duration: 0.3, ease: "easeOut" }}
@@ -203,21 +209,6 @@ function ResultsContent({
           placeCount={data.places.length}
           onBack={onBack}
         />
-      </motion.div>
-
-      {/* Section header — fades up */}
-      <motion.div
-        className="flex items-end justify-between px-4 pt-5"
-        initial={{ opacity: 0, y: 12 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.4, ease: [0.22, 1, 0.36, 1], delay: 0.1 }}
-      >
-        <div>
-          <h2 className="text-xl font-bold text-foreground">places to meet</h2>
-          <p className="mt-0.5 text-sm text-muted-foreground">
-            {data.places.length} spots found nearby
-          </p>
-        </div>
       </motion.div>
 
       {/* Map — fades in */}
@@ -238,7 +229,24 @@ function ResultsContent({
         </APIProvider>
       </motion.div>
 
-      <main className="flex-1 px-4 pt-4 pb-8">
+      <main className="min-h-0 flex-1 overflow-y-auto px-4 pt-5 pb-8">
+        {/* Section header — fades up */}
+        <motion.div
+          className="mb-4 flex items-end justify-between"
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.4, ease: [0.22, 1, 0.36, 1], delay: 0.25 }}
+        >
+          <div>
+            <h2 className="text-xl font-bold text-foreground">
+              places to meet
+            </h2>
+            <p className="mt-0.5 text-sm text-muted-foreground">
+              {data.places.length} spots found nearby
+            </p>
+          </div>
+        </motion.div>
+
         {/* Place cards — staggered entrance */}
         <div className="grid gap-3">
           {data.places.map((place, index) => (

--- a/src/routes/results.tsx
+++ b/src/routes/results.tsx
@@ -5,6 +5,7 @@ import { AnimatePresence, motion } from "framer-motion"
 import { MapPin } from "lucide-react"
 import type { Place } from "@/server/maps/types"
 import { useSearch } from "@/hooks/use-maps"
+import { CloudBackground } from "@/components/clouds"
 import { ResultsHeader } from "@/components/results/results-header"
 import { MiniMap } from "@/components/results/mini-map"
 import { PlaceCard } from "@/components/results/place-card"
@@ -45,22 +46,25 @@ function ResultsPage() {
   const isLoading = !searchResult.data
 
   return (
-    <div className="flex min-h-svh flex-col bg-background">
-      <AnimatePresence mode="wait">
-        {isLoading ? (
-          <ResultsLoadingScreen key="loading" />
-        ) : (
-          <ResultsContent
-            key="results"
-            data={searchResult.data}
-            selectedPlace={selectedPlace}
-            setSelectedPlace={setSelectedPlace}
-            isMapExpanded={isMapExpanded}
-            setIsMapExpanded={setIsMapExpanded}
-            onBack={() => navigate({ to: "/" })}
-          />
-        )}
-      </AnimatePresence>
+    <div className="sky-gradient relative flex min-h-svh flex-col overflow-hidden">
+      <CloudBackground />
+      <div className="relative z-10 flex min-h-svh flex-col">
+        <AnimatePresence mode="wait">
+          {isLoading ? (
+            <ResultsLoadingScreen key="loading" />
+          ) : (
+            <ResultsContent
+              key="results"
+              data={searchResult.data}
+              selectedPlace={selectedPlace}
+              setSelectedPlace={setSelectedPlace}
+              isMapExpanded={isMapExpanded}
+              setIsMapExpanded={setIsMapExpanded}
+              onBack={() => navigate({ to: "/" })}
+            />
+          )}
+        </AnimatePresence>
+      </div>
     </div>
   )
 }
@@ -93,7 +97,7 @@ function ResultsLoadingScreen() {
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.6, ease: [0.22, 1, 0.36, 1], delay: 0.1 }}
       >
-        <span className="text-lg font-bold tracking-tight text-sky-blue">
+        <span className="text-lg font-bold tracking-tight text-white">
           meet me halfway
         </span>
       </motion.div>
@@ -107,12 +111,12 @@ function ResultsLoadingScreen() {
       >
         {/* Pulsing rings */}
         <motion.div
-          className="absolute inset-0 m-auto size-12 rounded-full bg-sky-blue/20"
+          className="absolute inset-0 m-auto size-12 rounded-full bg-white/20"
           animate={{ scale: [1, 2.5], opacity: [0.4, 0] }}
           transition={{ duration: 2, repeat: Infinity, ease: "easeOut" }}
         />
         <motion.div
-          className="absolute inset-0 m-auto size-12 rounded-full bg-sky-blue/15"
+          className="absolute inset-0 m-auto size-12 rounded-full bg-white/15"
           animate={{ scale: [1, 2.5], opacity: [0.3, 0] }}
           transition={{
             duration: 2,
@@ -123,8 +127,8 @@ function ResultsLoadingScreen() {
         />
 
         {/* Pin icon */}
-        <div className="relative flex size-12 items-center justify-center rounded-full bg-sky-blue shadow-lg shadow-sky-blue/25">
-          <MapPin className="size-6 text-white" />
+        <div className="relative flex size-12 items-center justify-center rounded-full bg-white shadow-lg shadow-white/25">
+          <MapPin className="size-6 text-sky-blue" />
         </div>
       </motion.div>
 
@@ -133,7 +137,7 @@ function ResultsLoadingScreen() {
         <AnimatePresence mode="wait">
           <motion.p
             key={messageIndex}
-            className="text-center text-sm font-medium text-muted-foreground"
+            className="text-center text-sm font-medium text-white/80"
             initial={{ opacity: 0, y: 10 }}
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: -10 }}
@@ -153,8 +157,8 @@ function ResultsLoadingScreen() {
             animate={{
               backgroundColor:
                 i <= messageIndex
-                  ? "rgb(44, 173, 253)"
-                  : "rgb(44, 173, 253, 0.2)",
+                  ? "rgba(255, 255, 255, 1)"
+                  : "rgba(255, 255, 255, 0.3)",
               scale: i === messageIndex ? 1.3 : 1,
             }}
             transition={{ duration: 0.3 }}
@@ -230,10 +234,8 @@ function ResultsContent({
           transition={{ duration: 0.4, ease: [0.22, 1, 0.36, 1], delay: 0.25 }}
         >
           <div>
-            <h2 className="text-xl font-bold text-foreground">
-              places to meet
-            </h2>
-            <p className="mt-0.5 text-sm text-muted-foreground">
+            <h2 className="text-xl font-bold text-white">places to meet</h2>
+            <p className="mt-0.5 text-sm text-white/70">
               {data.places.length} spots found nearby
             </p>
           </div>

--- a/src/routes/results.tsx
+++ b/src/routes/results.tsx
@@ -46,25 +46,22 @@ function ResultsPage() {
   const isLoading = !searchResult.data
 
   return (
-    <div className="sky-gradient relative flex min-h-svh flex-col overflow-hidden">
-      <CloudBackground />
-      <div className="relative z-10 flex min-h-svh flex-col">
-        <AnimatePresence mode="wait">
-          {isLoading ? (
-            <ResultsLoadingScreen key="loading" />
-          ) : (
-            <ResultsContent
-              key="results"
-              data={searchResult.data}
-              selectedPlace={selectedPlace}
-              setSelectedPlace={setSelectedPlace}
-              isMapExpanded={isMapExpanded}
-              setIsMapExpanded={setIsMapExpanded}
-              onBack={() => navigate({ to: "/" })}
-            />
-          )}
-        </AnimatePresence>
-      </div>
+    <div className="flex min-h-svh flex-col bg-background">
+      <AnimatePresence mode="wait">
+        {isLoading ? (
+          <ResultsLoadingScreen key="loading" />
+        ) : (
+          <ResultsContent
+            key="results"
+            data={searchResult.data}
+            selectedPlace={selectedPlace}
+            setSelectedPlace={setSelectedPlace}
+            isMapExpanded={isMapExpanded}
+            setIsMapExpanded={setIsMapExpanded}
+            onBack={() => navigate({ to: "/" })}
+          />
+        )}
+      </AnimatePresence>
     </div>
   )
 }
@@ -84,12 +81,13 @@ function ResultsLoadingScreen() {
 
   return (
     <motion.div
-      className="flex flex-1 flex-col items-center justify-center gap-8 px-6"
+      className="sky-gradient relative flex flex-1 flex-col items-center justify-center gap-8 overflow-hidden px-6"
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       exit={{ opacity: 0, scale: 0.96 }}
       transition={{ duration: 0.4, ease: [0.22, 1, 0.36, 1] }}
     >
+      <CloudBackground />
       {/* Logo */}
       <motion.div
         className="flex flex-col items-center gap-6"
@@ -234,8 +232,10 @@ function ResultsContent({
           transition={{ duration: 0.4, ease: [0.22, 1, 0.36, 1], delay: 0.25 }}
         >
           <div>
-            <h2 className="text-xl font-bold text-white">places to meet</h2>
-            <p className="mt-0.5 text-sm text-white/70">
+            <h2 className="text-xl font-bold text-foreground">
+              places to meet
+            </h2>
+            <p className="mt-0.5 text-sm text-muted-foreground">
               {data.places.length} spots found nearby
             </p>
           </div>

--- a/src/server/maps/__tests__/test-simulation.ts
+++ b/src/server/maps/__tests__/test-simulation.ts
@@ -236,6 +236,7 @@ export class SimulatedWorld {
         id: placeId,
         displayName: { text: `simulated venue ${placeId}` },
         formattedAddress: `${placeCoords.latitude.toFixed(4)}, ${placeCoords.longitude.toFixed(4)}`,
+        location: placeCoords,
         rating: 4.0 + Math.random(),
         googleMapsUri: `https://maps.google.com/?q=${placeCoords.latitude},${placeCoords.longitude}`,
         websiteUri: "",

--- a/src/server/maps/fetch-nearby-activities.ts
+++ b/src/server/maps/fetch-nearby-activities.ts
@@ -12,7 +12,7 @@ export async function fetchNearbyActivities(
         "Content-Type": "application/json",
         "X-Goog-Api-Key": process.env.MAPS_API_KEY!,
         "X-Goog-FieldMask":
-          "places.id,places.displayName.text,places.formattedAddress,places.rating,places.googleMapsUri,places.websiteUri,places.currentOpeningHours.weekdayDescriptions,places.types,places.photos",
+          "places.id,places.displayName.text,places.formattedAddress,places.location,places.rating,places.googleMapsUri,places.websiteUri,places.currentOpeningHours.weekdayDescriptions,places.types,places.photos",
       },
       body: JSON.stringify({
         includedTypes: [

--- a/src/server/maps/types.ts
+++ b/src/server/maps/types.ts
@@ -30,6 +30,7 @@ export type PlacePhoto = {
 export type Place = {
   id: string
   formattedAddress: string
+  location: Coordinates
   rating: number
   googleMapsUri: string
   websiteUri: string


### PR DESCRIPTION
## Summary

- Replaces `bg-primary/10 text-primary` (green) with theme-consistent colors on category badge pills in both the place card and detail sheet
- Adds the `sky-gradient` background and `CloudBackground` component to the results page, matching the landing page aesthetic
- Updates the results header, place cards, and loading screen to use frosted-glass styling (`bg-white/15 backdrop-blur-xl`) with white text for readability over the sky gradient

Closes #14