### PR TITLE
fix: limit address inputs to 5 and make form scrollable on short screens

### DIFF
--- a/src/components/landing-form.tsx
+++ b/src/components/landing-form.tsx
@@ -12,6 +12,8 @@ type FormEntry = {
   label: string
 }
 
+const MAX_ENTRIES = 5
+
 let nextId = 0
 function createEntry(placeId = "", label = ""): FormEntry {
   return { id: `entry-${Date.now()}-${nextId++}`, placeId, label }
@@ -82,7 +84,7 @@ export function LandingForm({
     <AnimatePresence>
       {visible && (
         <motion.div
-          className="absolute inset-x-0 top-[35vh] bottom-0 z-20 flex items-start justify-center px-8 md:top-[42vh] md:px-6"
+          className="absolute inset-x-0 top-[35vh] bottom-0 z-20 flex items-start justify-center overflow-y-auto px-8 md:top-[42vh] md:px-6"
           initial={{ opacity: 0, y: 60 }}
           animate={{ opacity: 1, y: 0 }}
           exit={{ opacity: 0, y: 60 }}
@@ -167,6 +169,7 @@ export function LandingForm({
                   variant="ghost"
                   size="sm"
                   className="text-white/80 hover:bg-white/20 hover:text-white"
+                  disabled={entries.length >= MAX_ENTRIES}
                 >
                   <Plus className="h-4 w-4" />
                   add friend


### PR DESCRIPTION
## Summary

Closes #12

- Caps address inputs at 5 — the \"add friend\" button is disabled once the limit is reached
- Adds `overflow-y-auto` to the form's existing absolute wrapper so the form scrolls within its own bounded region (35vh → bottom of viewport) on short screens, with no layout changes to the page root