### PR TITLE
feat: show per-person drive times and fairness on results page

### DIFF
--- a/src/components/results/drive-times.tsx
+++ b/src/components/results/drive-times.tsx
@@ -1,0 +1,58 @@
+import { Car, Clock } from "lucide-react"
+
+type DriveTimesProps = {
+  originNames: Array<string>
+  travelTimes: Array<number>
+  timeDifference: number
+}
+
+function formatMinutes(seconds: number): string {
+  const minutes = Math.round(seconds / 60)
+  return `~${minutes} min`
+}
+
+export function DriveTimes({
+  originNames,
+  travelTimes,
+  timeDifference,
+}: DriveTimesProps) {
+  if (travelTimes.length === 0) return null
+
+  const diffMinutes = Math.round(timeDifference / 60)
+
+  return (
+    <div className="mx-4 rounded-xl border border-border/60 bg-muted/30 p-4">
+      <div className="mb-3 flex items-center gap-2">
+        <Car className="size-4 text-sky-blue" />
+        <h3 className="text-sm font-semibold text-foreground">drive times</h3>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        {travelTimes.map((time, index) => (
+          <div
+            key={index}
+            className="flex items-center justify-between text-sm"
+          >
+            <span className="text-muted-foreground">
+              {originNames[index]?.toLowerCase() ?? `person ${index + 1}`}
+            </span>
+            <span className="font-medium text-foreground">
+              {formatMinutes(time)}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      {travelTimes.length >= 2 && (
+        <div className="mt-3 flex items-center gap-1.5 border-t border-border/40 pt-3">
+          <Clock className="size-3.5 text-muted-foreground" />
+          <span className="text-xs text-muted-foreground">
+            {diffMinutes <= 1
+              ? "almost perfectly fair"
+              : `${diffMinutes} min difference`}
+          </span>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/routes/results.tsx
+++ b/src/routes/results.tsx
@@ -8,6 +8,7 @@ import { useSearch } from "@/hooks/use-maps"
 import { CloudBackground } from "@/components/clouds"
 import { ResultsHeader } from "@/components/results/results-header"
 import { MiniMap } from "@/components/results/mini-map"
+import { DriveTimes } from "@/components/results/drive-times"
 import { PlaceCard } from "@/components/results/place-card"
 import { PlaceDetailSheet } from "@/components/results/place-detail-sheet"
 
@@ -185,6 +186,8 @@ function ResultsContent({
 }) {
   const cityName = data.snap?.cityName || "Midpoint"
   const filteredPlaces = data.places.filter((place) => place.photos?.length)
+  const bestIteration = data.iterations.find((it) => it.isBest)
+  const travelTimes = bestIteration?.travelTimes ?? []
 
   return (
     <motion.div
@@ -224,6 +227,22 @@ function ResultsContent({
           />
         </APIProvider>
       </motion.div>
+
+      {/* Drive times — fades in */}
+      {travelTimes.length > 0 && (
+        <motion.div
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.4, ease: [0.22, 1, 0.36, 1], delay: 0.2 }}
+          className="pt-4"
+        >
+          <DriveTimes
+            originNames={data.originNames}
+            travelTimes={travelTimes}
+            timeDifference={data.performance.timeDifference}
+          />
+        </motion.div>
+      )}
 
       <main className="px-4 pt-5 pb-8">
         {/* Section header — fades up */}

--- a/src/server/maps/__tests__/test-simulation.ts
+++ b/src/server/maps/__tests__/test-simulation.ts
@@ -203,7 +203,10 @@ export class SimulatedWorld {
     if (!coords) {
       throw new Error(`SimulatedWorld: unknown placeId "${placeId}"`)
     }
-    return Promise.resolve({ location: coords })
+    return Promise.resolve({
+      location: coords,
+      displayName: { text: placeId },
+    })
   }
 
   /** Mock for fetchNearbyActivities */

--- a/src/server/maps/fetch-place-details.ts
+++ b/src/server/maps/fetch-place-details.ts
@@ -12,7 +12,7 @@ export async function fetchPlaceDetails(
   const response = await fetch(url.toString(), {
     headers: {
       "X-Goog-Api-Key": process.env.MAPS_API_KEY!,
-      "X-Goog-FieldMask": "location",
+      "X-Goog-FieldMask": "location,displayName",
     },
   })
 
@@ -27,6 +27,9 @@ export async function fetchPlaceDetails(
     location: {
       longitude: number
       latitude: number
+    }
+    displayName: {
+      text: string
     }
   }
 

--- a/src/server/maps/search.ts
+++ b/src/server/maps/search.ts
@@ -317,6 +317,7 @@ export async function searchHandler(data: {
     latitude: d.location.latitude,
     longitude: d.location.longitude,
   }))
+  const originNames = details.map((d) => d.displayName.text)
 
   // Phase 1: Compute initial midpoint
   // For 2 people: geometric centroid (midpoint of the line)
@@ -709,6 +710,7 @@ export async function searchHandler(data: {
 
   return {
     coordinates,
+    originNames,
     midpoint: bestMidpoint,
     places: finalPlaces,
     iterations,

--- a/src/server/maps/types.ts
+++ b/src/server/maps/types.ts
@@ -63,6 +63,7 @@ export type SnapResult = {
 
 export type SearchResult = {
   coordinates: Array<Coordinates>
+  originNames: Array<string>
   midpoint: Coordinates
   places: Array<Place>
   iterations: Array<IterationResult>


### PR DESCRIPTION
## Summary
- Display each person's driving time to the meeting point on the results page, using origin place names fetched from Google Places API
- Show a fairness summary (time difference between travelers, or "almost perfectly fair" when ≤1 min)
- New `DriveTimes` component rendered between the map and place cards with a staggered entrance animation

Closes #23